### PR TITLE
Validate binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ install-sh
 libtool.m4
 missing
 Makefile.in
+tags
+*.swp

--- a/imagegw/src/converters.py
+++ b/imagegw/src/converters.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import shutil
+from util import program_exists
 
 """
 Shifter, Copyright (c) 2015, The Regents of the University of California,
@@ -66,6 +67,7 @@ def generateCramFSImage(expandedPath, imagePath):
     """
     Creates a CramFS based image
     """
+    program_exists ('mkfs.cramfs')
     ret = subprocess.call(["mkfs.cramfs", expandedPath, imagePath], stdout=fdnull, stderr=fdnull)
     if ret != 0:
         # error handling
@@ -82,6 +84,9 @@ def generateSquashFSImage(expandedPath, imagePath):
     """
     Creates a SquashFS based image
     """
+    # This will raise an exception if mksquashfs tool is not found
+    # it should be handled by the calling function
+    program_exists ('mksquashfs')
 
     ret = subprocess.call(["mksquashfs", expandedPath, imagePath, "-all-root"])
     if ret != 0:
@@ -136,3 +141,4 @@ def writemeta(format,meta,metafile):
         mf.close()
     # Some error must have occurred
     return True
+

--- a/imagegw/src/util.py
+++ b/imagegw/src/util.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python
+
+import os
+import subprocess
+import shutil
+
+"""
+Shifter, Copyright (c) 2015, The Regents of the University of California,
+through Lawrence Berkeley National Laboratory (subject to receipt of any
+required approvals from the U.S. Dept. of Energy).  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+ 1. Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+ 3. Neither the name of the University of California, Lawrence Berkeley
+    National Laboratory, U.S. Dept. of Energy nor the names of its
+    contributors may be used to endorse or promote products derived from this
+    software without specific prior written permission.`
+
+See LICENSE for full text.
+"""
+
+"""
+  -------
+  util.py
+  -------
+
+  Collection of functions that provide miscellaneous utilities
+
+"""
+def program_exists(program):
+    """
+    Checks if a program (bin) exists and raises an exception if not found. 
+    """
+    if which(program) == None:
+        raise IOError ('Binary ' + str(program) + ' not found or not executable.')
+    return True
+
+def which(program):
+    """
+    Sees if a program (bin) is executable and returns the path
+    Borrowed from http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python
+    """
+    def is_exe(fpath):
+        return os.path.exists(fpath) and os.access(fpath, os.X_OK)
+
+    def ext_candidates(fpath):
+        yield fpath
+        for ext in os.environ.get("PATHEXT", "").split(os.pathsep):
+            yield fpath + ext
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            for candidate in ext_candidates(exe_file):
+                if is_exe(candidate):
+                    return candidate
+
+    return None


### PR DESCRIPTION
Adding a simple validation for some binaries that are used by imageGateway. For instance, if mksquashfs is not present on the system, it is difficult understand that it is the missing piece just by looking at error message when the image conversion fails.

Alternatively this could be done at launch time, but I'm unsure how it would play with the whole workers/threads system.