### PR TITLE
shifter.spec: create required configure script

### DIFF
--- a/shifter.spec
+++ b/shifter.spec
@@ -34,10 +34,12 @@ Group:    System Environment/Base
 BuildRequires: munge
 BuildRequires: libcurl-devel
 BuildRequires: libjson-c-devel
+BuildRequires: pam-devel
 %else
 BuildRequires: munge
 BuildRequires: libcurl libcurl-devel
 BuildRequires: json-c json-c-devel
+BuildRequires: pam-devel
 %endif
 %description runtime
 runtime and user interface components of shifter

--- a/shifter.spec
+++ b/shifter.spec
@@ -15,6 +15,7 @@ Shifter - environment containers for HPC
 
 %prep
 %setup -q
+./autogen.sh
 
 %build
 ## build udiRoot (runtime) first


### PR DESCRIPTION
Currently the spec file results in rpmbuild trying to call ./configure
before it actually exists. To fix this we call ./autogen.sh first from
the %prep section.