### PR TITLE
Write docker layers to different loc

### DIFF
--- a/imagegw/shifter_imagegw/converters.py
+++ b/imagegw/shifter_imagegw/converters.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import shutil
+import tempfile
 from shifter_imagegw.util import program_exists
 
 """
@@ -105,17 +106,24 @@ def convert(format,expandedPath,imagePath):
         print "file already exist"
         return True
 
-    imageTempPath=imagePath+'.partial'
+    (dirname,fname) = os.path.split(imagePath)
+    (imageTempFd,imageTempPath) = tempfile.mkstemp('.partial', fname, dirname)
+    os.close(imageTempFd)
 
-    success=False
-    if format=='squashfs':
-        success=generateSquashFSImage(expandedPath,imageTempPath)
-    elif format=='cramfs':
-        success=generateCramFSImage(expandedPath,imageTempPath)
-    elif format=='ext4':
-        success=generateExt4Image(expandedPath,imageTempPath)
-    else:
-        raise NotImplementedError("%s not a supported format"%format)
+    try:
+        success=False
+        if format=='squashfs':
+            success=generateSquashFSImage(expandedPath,imageTempPath)
+        elif format=='cramfs':
+            success=generateCramFSImage(expandedPath,imageTempPath)
+        elif format=='ext4':
+            success=generateExt4Image(expandedPath,imageTempPath)
+        else:
+            raise NotImplementedError("%s not a supported format"%format)
+    except:
+        os.unlink(imageTempPath)
+        raise
+
     if not success:
         return False
     try:

--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -333,8 +333,6 @@ class dockerv2Handle():
                 buff = r1.read(readsz)
                 if buff is None:
                     break
-                if type(buff) != str:
-                    print buff
 
                 output_fp.write(buff)
                 nread += len(buff)


### PR DESCRIPTION
use temporary filenames for download cache writing (as well as image generation) to prevent multiple workers on same machine from clobbering each other.

also add more logic to remove those temporary files should something go wrong.

this should resolve issue #9 