### PR TITLE
Dockerv2 layer extraction

### DIFF
--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -13,6 +13,8 @@ import tempfile
 import socket
 import urllib2
 import shifter_imagegw
+import stat
+import shutil
 
 ## Shifter, Copyright (c) 2015, The Regents of the University of California,
 ## through Lawrence Berkeley National Laboratory (subject to receipt of any

--- a/imagegw/test/imagemngr_test.py
+++ b/imagegw/test/imagemngr_test.py
@@ -491,7 +491,7 @@ class ImageMngrTestCase(unittest.TestCase):
         # Cause a failure
         self.images.drop()
         rec=self.m.pull(session,pr,TESTMODE=2)
-        time.sleep(1)
+        time.sleep(10)
         assert rec is not None
         id=rec['_id']
         state=self.m.get_state(id)


### PR DESCRIPTION
This pull request addresses issue #50 by identifying all symlinks in a layer to be applied, determine if any symlinks are going to replace an existing directory, and if so, removes the directory (to all the symlink to be created).  Automated tar options to do similar were too destructive and deleted more directories than was required.

It also removes the need for the tar wrapper by explicitly opening up permissions to all files in each layer after the layer is expanded.