### PR TITLE
Fixed Kernel config file location

### DIFF
--- a/extra/shifter_cle6_kmod_deps.spec
+++ b/extra/shifter_cle6_kmod_deps.spec
@@ -7,7 +7,7 @@
 
 Name:           shifter_cle6_kmod_deps-%(uname -r)
 Version:        1.0
-Release:        2
+Release:        3
 License:        GPL
 BuildRequires: kernel-source kernel-syms
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -20,9 +20,15 @@ xfs, ext4 and deps
 
 %build
 cd /usr/src/linux
-cp /proc/config.gz ./
-gunzip config.gz
-mv config .config
+if [ -e "arch/x86/configs/cray_ari_c_defconfi" ]; then
+  # assuming we are on a chroot environment
+  cp arch/x86/configs/cray_ari_c_defconfig .config
+else
+  # assuming we are on a compute node
+  cp /proc/config.gz ./
+  gunzip config.gz
+  mv config .config
+fi
 make oldconfig
 make modules_prepare
 make M=fs/xfs CONFIG_XFS_FS=m
@@ -48,5 +54,7 @@ depmod -a
 /lib/*
 
 %changelog
+* Mon Aug 08 2016 Miguel Gila <miguel.gila@cscs.ch> 1.0-3
+ - Added if case to support building on chroot environment
 * Wed Jul 20 2016 Miguel Gila <miguel.gila@cscs.ch> 1.0-2
  - Fixed Kernel config file location

--- a/extra/shifter_cle6_kmod_deps.spec
+++ b/extra/shifter_cle6_kmod_deps.spec
@@ -20,7 +20,7 @@ xfs, ext4 and deps
 
 %build
 cd /usr/src/linux
-if [ -e "arch/x86/configs/cray_ari_c_defconfi" ]; then
+if [ -e "arch/x86/configs/cray_ari_c_defconfig" ]; then
   # assuming we are on a chroot environment
   cp arch/x86/configs/cray_ari_c_defconfig .config
 else

--- a/extra/shifter_cle6_kmod_deps.spec
+++ b/extra/shifter_cle6_kmod_deps.spec
@@ -7,7 +7,7 @@
 
 Name:           shifter_cle6_kmod_deps-%(uname -r)
 Version:        1.0
-Release:        1
+Release:        2
 License:        GPL
 BuildRequires: kernel-source kernel-syms
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -20,7 +20,9 @@ xfs, ext4 and deps
 
 %build
 cd /usr/src/linux
-cp arch/x86/configs/cray_ari_c_defconfig .config
+cp /proc/config.gz ./
+gunzip config.gz
+mv config .config
 make oldconfig
 make modules_prepare
 make M=fs/xfs CONFIG_XFS_FS=m
@@ -45,4 +47,6 @@ depmod -a
 %defattr(-,root,root)
 /lib/*
 
-
+%changelog
+* Wed Jul 20 2016 Miguel Gila <miguel.gila@cscs.ch> 1.0-2
+ - Fixed Kernel config file location


### PR DESCRIPTION
I've added a few modifications to be able to build RPMs on CLE6 on our systems. For some reason  arch/x86/configs/cray_ari_c_defconfig did not exist here and cannot find it, but /proc/config.gz is always there.