### PR TITLE
src/Makefile.am:  Fix "make distcheck"

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,5 +78,5 @@ shifterimg_SOURCES = $(SHIFTERIMG_SOURCES)
 shifterimg_LDFLAGS = $(MUNGE_LDFLAGS) $(JSON_LDFLAGS) $(LIBCURL) $(MUNGE_LDFLAGS)
 shifterimg_CPPFLAGS = $(AM_CPPFLAGS) $(MUNGE_CPPFLAGS) $(JSON_CPPFLAGS) $(LIBCURL_CPPFLAGS) $(MUNGE_CPPFLAGS)
 
-install-data-hook:
-	/bin/chmod 4755 $(DESTDIR)/$(bindir)/shifter
+install-exec-hook:
+	/bin/chmod 4755 $(DESTDIR)$(bindir)/shifter


### PR DESCRIPTION
This change fixes `make distcheck` by using the correct type of automake hook to `chmod` the `shifter` binary.
