### PR TITLE
Prevent extraction collision

### DIFF
--- a/imagegw/shifter_imagegw/converters.py
+++ b/imagegw/shifter_imagegw/converters.py
@@ -103,7 +103,7 @@ def generateSquashFSImage(expandedPath, imagePath):
 
 def convert(format,expandedPath,imagePath):
     if os.path.exists(imagePath):
-        print "file already exist"
+        print "file already exists"
         return True
 
     (dirname,fname) = os.path.split(imagePath)

--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -73,6 +73,10 @@ class dockerv2Handle():
     allowAuthenticated = True
     checkLayerChecksums = True
 
+    # excluding this blobSum because it translates to an empty tar file
+    # and python 2.6 throws an exception when an open is attempted
+    excludeBlobSums = ['sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4']
+
     def __init__(self, imageIdent, options = None, updater=None):
         """
         Initialize an instance of the dockerv2 class.
@@ -163,6 +167,12 @@ class dockerv2Handle():
     def log(self,state,message=''):
         if self.updater is not None:
             self.updater.update_status(state,message)
+
+    def excludeLayer(self, blobsum):
+        ## TODO: add better verfication of the blobsum, potentially give other
+        ## routes to mask out a layer with this function
+        if blobsum not in self.excludeBlobSums:
+            self.excludeBlobSums.append(blobsum)
 
     def setupHttpConn(self, url, cacert=None):
         (protocol, url) = url.split('://', 1)
@@ -301,6 +311,10 @@ class dockerv2Handle():
             (eldest,youngest) = self.constructImageMetadata(manifest)
             layer = eldest
             while layer is not None:
+                if layer['fsLayer']['blobSum'] in self.excludeBlobSums:
+                    layer = layer['child']
+                    continue
+
                 self.log("PULLING","Pulling layer %s"%layer['fsLayer']['blobSum'])
                 self.saveLayer(layer['fsLayer']['blobSum'], cachedir)
                 layer = layer['child']
@@ -464,9 +478,7 @@ class dockerv2Handle():
         layerPaths = []
         layer = baseLayer
         while layer is not None:
-            # excluding this blobSum because it translates to an empty tar file
-            # and python 2.6 throws an exception when an open is attempted
-            if layer['fsLayer']['blobSum'] == 'sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4':
+            if layer['fsLayer']['blobSum'] in self.excludeBlobSums:
                 layer = layer['child']
                 continue
 
@@ -518,9 +530,7 @@ class dockerv2Handle():
         layerIdx = 0
         layer = baseLayer
         while layer is not None:
-            # excluding this blobSum because it translates to an empty tar file
-            # and python 2.6 throws an exception when an open is attempted
-            if layer['fsLayer']['blobSum'] == 'sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4':
+            if layer['fsLayer']['blobSum'] in self.excludeBlobSums:
                 layer = layer['child']
                 continue
 

--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -390,7 +390,6 @@ class dockerv2Handle():
         try:
             readsz = 4 * 1024 * 1024 # read 4MB chunks
             while nread < maxlen:
-                ## TODO: consider making this an os.read() to allow a timeout
                 buff = r1.read(readsz)
                 if buff is None:
                     break

--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -371,6 +371,7 @@ class dockerv2Handle():
         try:
             readsz = 4 * 1024 * 1024 # read 4MB chunks
             while nread < maxlen:
+                ## TODO: consider making this an os.read() to allow a timeout
                 buff = r1.read(readsz)
                 if buff is None:
                     break
@@ -463,6 +464,12 @@ class dockerv2Handle():
         layerPaths = []
         layer = baseLayer
         while layer is not None:
+            # excluding this blobSum because it translates to an empty tar file
+            # and python 2.6 throws an exception when an open is attempted
+            if layer['fsLayer']['blobSum'] == 'sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4':
+                layer = layer['child']
+                continue
+
             tfname = os.path.join(cachedir,'%s.tar'%(layer['fsLayer']['blobSum']))
             tfp = tarfile.open(tfname, 'r:gz')
 
@@ -511,6 +518,12 @@ class dockerv2Handle():
         layerIdx = 0
         layer = baseLayer
         while layer is not None:
+            # excluding this blobSum because it translates to an empty tar file
+            # and python 2.6 throws an exception when an open is attempted
+            if layer['fsLayer']['blobSum'] == 'sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4':
+                layer = layer['child']
+                continue
+
             tfname = os.path.join(cachedir,'%s.tar' % (layer['fsLayer']['blobSum']))
             tfp = tarfile.open(tfname, 'r:gz')
             members = layerPaths[layerIdx]

--- a/imagegw/shifter_imagegw/imageworker.py
+++ b/imagegw/shifter_imagegw/imageworker.py
@@ -203,8 +203,8 @@ def convert_image(request):
     edir=config['ExpandDirectory']
 
     ## initially write image in tempfile
-    (fp,imagefile)=tempfile.mkstemp(prefix=request['id'],suffix=format,dir=edir)
-    fp.close()
+    (fd,imagefile)=tempfile.mkstemp(prefix=request['id'],suffix=format,dir=edir)
+    os.close(fd)
     request['imagefile']=imagefile
 
     status=converters.convert(format,request['expandedpath'],imagefile)
@@ -228,8 +228,8 @@ def write_metadata(request):
     edir=config['ExpandDirectory']
 
     ## initially write metadata to tempfile
-    (fp,metafile)=tempfile.mkstemp(prefix=request['id'],suffix='meta',dir=edir)
-    fp.close()
+    (fd,metafile)=tempfile.mkstemp(prefix=request['id'],suffix='meta',dir=edir)
+    os.close(fd)
     request['metafile']=metafile
 
     status=converters.writemeta(format,meta,metafile)

--- a/imagegw/shifter_imagegw/imageworker.py
+++ b/imagegw/shifter_imagegw/imageworker.py
@@ -202,18 +202,10 @@ def convert_image(request):
     cdir=config['CacheDirectory']
     edir=config['ExpandDirectory']
 
-    ## initially write image in tempfile
-    (fd,imagefile)=tempfile.mkstemp(prefix=request['id'],suffix=format,dir=edir)
-    os.close(fd)
+    imagefile=os.path.join(edir, '%s.%s' % (request['id'], format))
     request['imagefile']=imagefile
 
     status=converters.convert(format,request['expandedpath'],imagefile)
-
-    ## after success move to final name
-    final_imagefile=os.path.join(edir, '%s.%s' % (request['id'], format))
-    shutil.move(imagefile, final_imagefile)
-    request['imagefile']=final_imagefile
-
     return status
 
 def write_metadata(request):

--- a/imagegw/shifter_imagegw/imageworker.py
+++ b/imagegw/shifter_imagegw/imageworker.py
@@ -10,6 +10,7 @@ import re
 import shutil
 import sys
 import subprocess
+import tempfile
 from pymongo import MongoClient
 from bson.objectid import ObjectId
 from random import randint

--- a/imagegw/shifter_imagegw/imageworker.py
+++ b/imagegw/shifter_imagegw/imageworker.py
@@ -154,13 +154,13 @@ def pull_image(request,updater=defupdater):
             updater.update_status("PULLING",'Getting manifest')
             manifest = dh.getImageManifest()
             resp=dh.pull_layers(manifest,cdir)
+            request['meta']=resp
+
             expandedpath = tempfile.mkdtemp(suffix='extract', prefix=str(resp['id']), dir=edir)
-            if not os.path.exists(expandedpath):
-                os.mkdir(expandedpath)
+            request['expandedpath']=expandedpath
+
             updater.update_status("PULLING",'Extracting Layers')
             dh.extractDockerLayers(expandedpath, dh.get_eldest(), cachedir=cdir)
-            request['meta']=resp
-            request['expandedpath']=expandedpath
             return True
         except:
             logging.warn(sys.exc_value)
@@ -334,7 +334,9 @@ def dopull(self,request,TESTMODE=0):
         logging.error("ERROR: dopull failed system=%s tag=%s"%(request['system'],request['tag']))
         print sys.exc_value
         self.update_state(state='FAILURE')
-        #cleanup_temporary(request)
+
+        ## TODO: add a debugging flag and only disable cleanup if debugging
+        cleanup_temporary(request)
         raise
 
 

--- a/imagegw/shifter_imagegw/imageworker.py
+++ b/imagegw/shifter_imagegw/imageworker.py
@@ -154,7 +154,7 @@ def pull_image(request,updater=defupdater):
             updater.update_status("PULLING",'Getting manifest')
             manifest = dh.getImageManifest()
             resp=dh.pull_layers(manifest,cdir)
-            expandedpath=os.path.join(edir,str(resp['id']))
+            expandedpath = tempfile.mkdtemp(suffix='extract', prefix=str(resp['id']), dir=edir)
             if not os.path.exists(expandedpath):
                 os.mkdir(expandedpath)
             updater.update_status("PULLING",'Extracting Layers')


### PR DESCRIPTION
Hi Shane,

Please review these changes, they are intended to fix two possible edge cases.

1) python2.6 tarfile doesn't like the empty tar layer that docker emits, so it is explicitly ignored

2) if a layer extraction fails for some reason (disk full, failure to open tar file, permissions issue, etc), I've had cases where re-extracting to the same directory can become the new failure

3) If exceptions occur, cleanup, this should help production facilities, we should add a debugging flag to explicitly keep intermediates