### PR TITLE
Implicit latest

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,8 @@
 * Only allow shifter to automatically create mount points on its tmpfs/ramfs
 * Enable docker-type images to implicitly assume "latest" if no tag is 
   specified by user
+* Ensure failed image pulls are fully cleaned up
+* Check if the current image version is installed on the platform before pulling
 
 16.04.0
 ===========

--- a/NEWS
+++ b/NEWS
@@ -22,6 +22,8 @@
 * Allow sshd to be explicitly enabled in SLURM integration
 * Allow ccm-emulation-mode to be explicity enabled in SLURM integration
 * Only allow shifter to automatically create mount points on its tmpfs/ramfs
+* Enable docker-type images to implicitly assume "latest" if no tag is 
+  specified by user
 
 16.04.0
 ===========

--- a/imagegw/shifter_imagegw/api/__init__.py
+++ b/imagegw/shifter_imagegw/api/__init__.py
@@ -108,6 +108,9 @@ def list(system):
 # This will lookup the status of the requested image.
 @app.route('/api/lookup/<system>/<type>/<path:tag>/', methods=["GET"])
 def lookup(system,type,tag):
+    if type == "docker" and tag.find(':') == -1:
+        tag = '%s:latest' % (tag)
+
     auth=request.headers.get(AUTH_HEADER)
     app.logger.debug("lookup system=%s type=%s tag=%s auth=%s"%(system,type,tag,auth))
     i={'system':system,'itype':type,'tag':tag}
@@ -137,6 +140,9 @@ def lookup(system,type,tag):
 # This will pull the requested image.
 @app.route('/api/pull/<system>/<type>/<path:tag>/', methods=["POST"])
 def pull(system,type,tag):
+    if type == "docker" and tag.find(':') == -1:
+        tag = '%s:latest' % (tag)
+
     auth=request.headers.get(AUTH_HEADER)
     app.logger.debug("pull system=%s type=%s tag=%s"%(system,type,tag))
     i={'system':system,'itype':type,'tag':tag}
@@ -167,6 +173,9 @@ def autoexpire(system):
 # This will expire an image which removes it from the cache.
 @app.route('/api/expire/<system>/<type>/<tag>/', methods=["GET"])
 def expire(system,type,tag):
+    if type == "docker" and tag.find(':') == -1:
+        tag = '%s:latest' % (tag)
+
     auth=request.headers.get(AUTH_HEADER)
     i={'system':system,'itype':type,'tag':tag}
     app.logger.debug("expire system=%s type=%s tag=%s"%(system,type,tag))


### PR DESCRIPTION
Hi Shane,

Here are two more features to consider:

1) worker examines local/remote system to check validity of image after pulling manifest but before pulling; if image is valid then the pull is short circuited; right now the validity check is limited to existence, however combined with some of the work to improve resilience this is not a terribly bad assumption

2) the api will automatically impute a `:latest` tag if none was supplied by the user in the specific case of a docker request; this is to make the behavior of shifter more similar to docker.  combined with the addition of default types in udiRoot.conf earlier in the dev cycle, this allows the following to work:

    shifter --image=ubuntu ...
which would be parsed by shifter and the imagegw to mean docker:ubuntu:latest

-Doug