### PR TITLE
shifter.spec: support the --dist option from rpmbuild

### DIFF
--- a/shifter.spec
+++ b/shifter.spec
@@ -4,7 +4,7 @@
 Summary:  shifter
 Name:     shifter
 Version:  16.08.0pre1
-Release:  1
+Release:  1%{?dist}
 License:  BSD (LBNL-modified)
 Group:    System Environment/Base
 URL:      https://github.com/NERSC/shifter


### PR DESCRIPTION
The RPM spec file supports the concept of a %{?dist} tag so that a
single spec file can support multiple distro releases.  It also
allows the user to pass through extra version information to allow
easy upgrades between RPMs (rather than having to force them).

The Fedora guidelines also say:

https://fedoraproject.org/wiki/Packaging:DistTag

> Use of the %{?dist} tag is mandatory in Fedora.

So it's a good idea to support (and easy to do so).

This is to fix issue #95 "Support RPM %{dist} syntax in spec file":