### PR TITLE
Specfile revamp

### DIFF
--- a/shifter.spec
+++ b/shifter.spec
@@ -14,7 +14,7 @@ Source0:  %{name}-%{version}.tar.gz
 %description
 Shifter enables container images for HPC. In a nutshell, Shifter
 allows an HPC system to efficiently and safely permit end-users to run
-jobs inside a docker image. Shifter consists of a few moving parts:
+jobs inside a Docker image. Shifter consists of a few moving parts:
   1) a utility that typically runs on the compute node that creates the
      runtime environment for the application,
   2) an image gateway service that pulls images from a registry and
@@ -43,7 +43,7 @@ BuildRequires: pam-devel
 %description runtime
 Shifter enables container images for HPC. In a nutshell, Shifter
 allows an HPC system to efficiently and safely permit end-users to run
-jobs inside a docker image. Shifter consists of a few moving parts:
+jobs inside a Docker image. Shifter consists of a few moving parts:
   1) a utility that typically runs on the compute node that creates the
      runtime environment for the application,
   2) an image gateway service that pulls images from a registry and
@@ -62,7 +62,7 @@ Summary: Image Manager/Gateway for Shifter
 %description imagegw
 Shifter enables container images for HPC. In a nutshell, Shifter
 allows an HPC system to efficiently and safely permit end-users to run
-jobs inside a docker image. Shifter consists of a few moving parts:
+jobs inside a Docker image. Shifter consists of a few moving parts:
   1) a utility that typically runs on the compute node that creates the
      runtime environment for the application,
   2) an image gateway service that pulls images from a registry and

--- a/shifter.spec
+++ b/shifter.spec
@@ -31,10 +31,13 @@ Shifter, please install the "shifter-runtime" package.
 Summary:  Runtime component(s) for NERSC Shifter (formerly udiRoot)
 Group:    System Environment/Base
 %if 0%{?suse_version}
-BuildRequires: munge, libcurl-devel, libjson-devel, pam-devel
+BuildRequires: munge, libcurl-devel, libjson-c-devel, pam-devel
 %else
-BuildRequires: munge-devel, gcc, gcc-c++, libcurl-devel, json-c-devel, pam-devel
-BuildRequires: libtool, autoconf, automake
+BuildRequires: munge-devel, gcc, gcc-c++
+BuildRequires: libtool autoconf automake
+BuildRequires: libcurl libcurl-devel
+BuildRequires: json-c json-c-devel
+BuildRequires: pam-devel
 %endif
 
 %description runtime

--- a/shifter.spec
+++ b/shifter.spec
@@ -123,6 +123,10 @@ rm -f $RPM_BUILD_ROOT/%{_libexecdir}/shifter/shifter_slurm_dws_support
 %endif
 
 
+%check
+%{__make} check
+
+
 %post runtime
 getent passwd > %{_sysconfdir}/shifter_etc_files/passwd
 getent group > %{_sysconfdir}/shifter_etc_files/group

--- a/shifter.spec
+++ b/shifter.spec
@@ -1,36 +1,117 @@
-%{!?_shifter_sysconfdir: %global _shifter_sysconfdir /etc/shifter}
+%{!?_shifter_sysconfdir: %{expand:%%global _shifter_sysconfdir %{_sysconfdir}/shifter}}
 %define _sysconfdir %_shifter_sysconfdir
 
-Summary:  shifter
+Summary:  NERSC Shifter -- Containers for HPC
 Name:     shifter
 Version:  16.08.0pre1
-Release:  1%{?dist}
+Release:  1.nersc%{?dist}
 License:  BSD (LBNL-modified)
 Group:    System Environment/Base
 URL:      https://github.com/NERSC/shifter
 Packager: Douglas Jacobsen <dmjacobsen@lbl.gov>
 Source0:  %{name}-%{version}.tar.gz
+
 %description
-Shifter - environment containers for HPC
+Shifter enables container images for HPC. In a nutshell, Shifter
+allows an HPC system to efficiently and safely permit end-users to run
+jobs inside a docker image. Shifter consists of a few moving parts:
+  1) a utility that typically runs on the compute node that creates the
+     runtime environment for the application,
+  2) an image gateway service that pulls images from a registry and
+     repacks them in a format suitable for the HPC system (typically
+     squashfs), and
+  3) example scripts/plugins to integrate Shifter with various batch
+     scheduler systems.
+
+This package contains no files; to install the core components of
+Shifter, please install the "shifter-runtime" package.
+
+
+%package  runtime
+Summary:  Runtime component(s) for NERSC Shifter (formerly udiRoot)
+Group:    System Environment/Base
+%if 0%{?suse_version}
+BuildRequires: munge, libcurl-devel, libjson-devel, pam-devel
+%else
+BuildRequires: munge-devel, gcc, gcc-c++, libcurl-devel, json-c-devel, pam-devel
+BuildRequires: libtool, autoconf, automake
+%endif
+
+%description runtime
+Shifter enables container images for HPC. In a nutshell, Shifter
+allows an HPC system to efficiently and safely permit end-users to run
+jobs inside a docker image. Shifter consists of a few moving parts:
+  1) a utility that typically runs on the compute node that creates the
+     runtime environment for the application,
+  2) an image gateway service that pulls images from a registry and
+     repacks them in a format suitable for the HPC system (typically
+     squashfs), and
+  3) example scripts/plugins to integrate Shifter with various batch
+     scheduler systems.
+
+This package contains the runtime and user interface components of
+Shifter.
+
+
+%package imagegw
+Summary: Image Manager/Gateway for Shifter
+
+%description imagegw
+Shifter enables container images for HPC. In a nutshell, Shifter
+allows an HPC system to efficiently and safely permit end-users to run
+jobs inside a docker image. Shifter consists of a few moving parts:
+  1) a utility that typically runs on the compute node that creates the
+     runtime environment for the application,
+  2) an image gateway service that pulls images from a registry and
+     repacks them in a format suitable for the HPC system (typically
+     squashfs), and
+  3) example scripts/plugins to integrate Shifter with various batch
+     scheduler systems.
+
+This package contains the Image Gateway and image management tools for
+use with Shifter.
+
+
+%if 0%{?with_slurm:1}
+%package slurm
+Summary:  SLURM Spank Module for Shifter
+BuildRequires: slurm-devel
+
+%description slurm
+Shifter enables container images for HPC. In a nutshell, Shifter
+allows an HPC system to efficiently and safely permit end-users to run
+jobs inside a docker image. Shifter consists of a few moving parts:
+  1) a utility that typically runs on the compute node that creates the
+     runtime environment for the application,
+  2) an image gateway service that pulls images from a registry and
+     repacks them in a format suitable for the HPC system (typically
+     squashfs), and
+  3) example scripts/plugins to integrate Shifter with various batch
+     scheduler systems.
+
+This package contains the Spank Plugin module which allows for the
+integration of Shifter with the SLURM Workload Manager.
+%endif
+
 
 %prep
 %setup -q
-if [[ ! -e ./configure ]]; then
-    ./autogen.sh
-fi
+test -x configure || ./autogen.sh
+
 
 %build
 ## build udiRoot (runtime) first
 %configure \
     %{?with_slurm:--with-slurm=%{?with_slurm}}
 
-MAKEFLAGS=%{?_smp_mflags} make
+MAKEFLAGS=%{?_smp_mflags} %{__make}
+
 
 %install
 %make_install
 
-rm -f $RPM_BUILD_ROOT/%{_sysconfdir}/shifter_etc_files/passwd
-rm -f $RPM_BUILD_ROOT/%{_sysconfdir}/shifter_etc_files/group
+: > $RPM_BUILD_ROOT/%{_sysconfdir}/shifter_etc_files/passwd
+: > $RPM_BUILD_ROOT/%{_sysconfdir}/shifter_etc_files/group
 %if %{?with_slurm:1}0
 rm -f $RPM_BUILD_ROOT/%{_libdir}/shifter/shifter_slurm.a
 rm -f $RPM_BUILD_ROOT/%{_libdir}/shifter/shifter_slurm.la
@@ -41,63 +122,47 @@ rm -f $RPM_BUILD_ROOT/%{_libdir}/shifter/shifter_slurm.so
 rm -f $RPM_BUILD_ROOT/%{_libexecdir}/shifter/shifter_slurm_dws_support
 %endif
 
-%package  runtime
-Summary:  runtime component for shifter (formerly udiRoot)
-Group:    System Environment/Base
-%if 0%{?suse_version}
-BuildRequires: munge
-BuildRequires: libcurl-devel
-BuildRequires: libjson-c-devel
-BuildRequires: pam-devel
-%else
-BuildRequires: munge-devel
-BuildRequires: gcc
-BuildRequires: gcc-c++
-BuildRequires: libtool autoconf automake
-BuildRequires: libcurl libcurl-devel
-BuildRequires: json-c json-c-devel
-BuildRequires: pam-devel
-%endif
-%description runtime
-runtime and user interface components of shifter
+
+%post runtime
+getent passwd > %{_sysconfdir}/shifter_etc_files/passwd
+getent group > %{_sysconfdir}/shifter_etc_files/group
+
+
+%files
+%defattr(-, root, root)
+%doc AUTHORS Dockerfile LICENSE NEWS README*
+
 %files runtime
+%defattr(-, root, root)
+%doc AUTHORS LICENSE NEWS README* udiRoot.conf.example
 %attr(4755, root, root) %{_bindir}/shifter
+%config(noreplace missingok) %verify(not filedigest mtime size) %{_sysconfdir}/shifter_etc_files/passwd
+%config(noreplace missingok) %verify(not filedigest mtime size) %{_sysconfdir}/shifter_etc_files/group
+%config(noreplace) %{_sysconfdir}/shifter_etc_files/nsswitch.conf
 %{_bindir}/shifterimg
 %{_sbindir}/setupRoot
 %{_sbindir}/unsetupRoot
 %{_libexecdir}/shifter/mount
 %{_libexecdir}/shifter/opt
 %{_sysconfdir}/udiRoot.conf.example
-%{_sysconfdir}/shifter_etc_files/nsswitch.conf
 
-%post runtime
-getent passwd > %{_sysconfdir}/shifter_etc_files/passwd
-getent group > %{_sysconfdir}/shifter_etc_files/group
-
-%if 0%{?with_slurm:1}
-%package slurm
-Summary:  slurm spank module for shifter
-BuildRequires: slurm-devel
-%description slurm
-spank module for integrating shifter into slurm
-%files slurm
-%{_libdir}/shifter/shifter_slurm.so
-%{_libexecdir}/shifter/shifter_slurm_dws_support
-%endif
-
-%package imagegw
-Summary: shifter image manager
-%description imagegw
-image manager
 %files imagegw
+%defattr(-, root, root)
+%doc AUTHORS LICENSE NEWS README*
 %{_libdir}/python2.*/site-packages/shifter_imagegw
 %{_libexecdir}/shifter/imagecli.py*
 %{_libexecdir}/shifter/imagegwapi.py*
 %{_libexecdir}/shifter/sitecustomize.py*
 %{_datadir}/shifter/requirements.txt
 %{_sysconfdir}/imagemanager.json.example
-%defattr(-,root,root)
 
+%if 0%{?with_slurm:1}
+%files slurm
+%defattr(-, root, root)
+%doc AUTHORS LICENSE NEWS README*
+%{_libdir}/shifter/shifter_slurm.so
+%{_libexecdir}/shifter/shifter_slurm_dws_support
+%endif
 
 
 %changelog

--- a/shifter.spec
+++ b/shifter.spec
@@ -122,6 +122,9 @@ MAKEFLAGS=%{?_smp_mflags} %{__make}
 %install
 %make_install
 
+# Create directory for Celery/ImageGW API logs
+%{__mkdir_p} $RPM_BUILD_ROOT%{_localstatedir}/log/%{name}_imagegw
+
 : > $RPM_BUILD_ROOT/%{_sysconfdir}/shifter_etc_files/passwd
 : > $RPM_BUILD_ROOT/%{_sysconfdir}/shifter_etc_files/group
 %if %{?with_slurm:1}0
@@ -178,6 +181,7 @@ getent group > %{_sysconfdir}/shifter_etc_files/group
 %files imagegw
 %defattr(-, root, root)
 %doc AUTHORS LICENSE NEWS README*
+%attr(0770, %{shifter_user}, %{shifter_group}) %dir %{_localstatedir}/log/%{name}_imagegw/
 %{_libdir}/python2.*/site-packages/shifter_imagegw
 %{_libexecdir}/shifter/imagecli.py*
 %{_libexecdir}/shifter/imagegwapi.py*


### PR DESCRIPTION
These changes make the spec file more "normalized" and "standardized" to match traditional ordering and such.  Also note that the `Release` field has been tagged (as RH prefer to be the only ones publishing unadorned RPMs).  And I added some verbosity to the `%description` fields.