### PR TITLE
Pullable fix

### DIFF
--- a/imagegw/shifter_imagegw/imagemngr.py
+++ b/imagegw/shifter_imagegw/imagemngr.py
@@ -237,7 +237,7 @@ class imagemngr:
     # Last thing... What if the pull somehow got hung or died in the middle
     # See if heartbeat is old
     # TODO: add pull timeout.  For now use 1 hour
-    if 'last_heartbeat' in rec:
+    if status!='READY' and 'last_heartbeat' in rec:
         if (time()-rec['last_heartbeat'])>3600:
             return True
 
@@ -491,7 +491,7 @@ class imagemngr:
       for rec in self.images.find({'status':{'$ne':'READY'},'system':system}):
           self.logger.debug(rec)
           if 'last_pull' not in rec:
-              self.logger.warning('image missing last_pull '+rec['_id'])
+              self.logger.warning('image missing last_pull pulltag'+rec['pulltag'])
               continue
           if rec['last_pull']<pulltimeout:
               removed.append(rec['_id'])


### PR DESCRIPTION
- Fixes pullable logic where a image was READY had recently  been re-pulled but had an old heartbeat.
  The heartbeat should just be used for non-READY images.
- Also small fix in logging for autoexpire