### PR TITLE
Shifter 16.08.2b packaging/distribution fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,4 +8,4 @@ if WITH_SLURM
 endif WITH_SLURM
 
 sysconf_DATA=udiRoot.conf.example
-EXTRA_DIST = AUTHORS Dockerfile LICENSE NEWS README.md autogen.sh config.h shifter.spec
+EXTRA_DIST = AUTHORS Dockerfile LICENSE NEWS README.md autogen.sh config.h contrib doc shifter.spec

--- a/extra/Makefile.am
+++ b/extra/Makefile.am
@@ -14,3 +14,5 @@ SHIFTER_SLURM_DWS_SUPPORT_SOURCES = \
 
 
 shifter_slurm_dws_support_SOURCES = $(SHIFTER_SLURM_DWS_SUPPORT_SOURCES)
+
+EXTRA_DIST = cle6 systemd

--- a/shifter.spec
+++ b/shifter.spec
@@ -115,7 +115,7 @@ test -x configure || ./autogen.sh
 %build
 ## build udiRoot (runtime) first
 %configure \
-    %{?with_slurm:--with-slurm=%{with_slurm}}
+    %{?with_slurm:--with-slurm=%{with_slurm}} %{?acflags}
 
 MAKEFLAGS=%{?_smp_mflags} %{__make}
 

--- a/shifter.spec
+++ b/shifter.spec
@@ -8,6 +8,13 @@
 %{expand:%%global shifter_gid %{?shifter_gid}%{!?shifter_gid:%{shifter_uid}}}
 %endif
 
+%if 0%{!?_without_systemd:1}
+%{!?_unitdir:          %global _without_systemd --without-systemd}
+%{!?systemd_requires:  %global _without_systemd --without-systemd}
+%endif
+
+%{?_with_slurm: %global with_slurm %{_prefix}}
+
 Summary:   NERSC Shifter -- Containers for HPC
 Name:      shifter
 Version:   16.08.2b
@@ -68,6 +75,9 @@ Shifter.
 %package imagegw
 Summary: Image Manager/Gateway for Shifter
 Requires(pre): shadow-utils
+%if 0%{!?_without_systemd:1}
+%{systemd_requires}
+%endif
 
 %description imagegw
 Shifter enables container images for HPC. In a nutshell, Shifter
@@ -124,7 +134,7 @@ MAKEFLAGS=%{?_smp_mflags} %{__make}
 %make_install
 
 # Create directory for Celery/ImageGW API logs
-%{__mkdir_p} $RPM_BUILD_ROOT%{_localstatedir}/log/%{name}_imagegw
+%{__mkdir_p} $RPM_BUILD_ROOT%{_localstatedir}/log/%{name}_imagegw{,_worker}
 
 : > $RPM_BUILD_ROOT/%{_sysconfdir}/shifter_etc_files/passwd
 : > $RPM_BUILD_ROOT/%{_sysconfdir}/shifter_etc_files/group
@@ -136,6 +146,13 @@ rm -f $RPM_BUILD_ROOT/%{_libdir}/shifter/shifter_slurm.a
 rm -f $RPM_BUILD_ROOT/%{_libdir}/shifter/shifter_slurm.la
 rm -f $RPM_BUILD_ROOT/%{_libdir}/shifter/shifter_slurm.so
 rm -f $RPM_BUILD_ROOT/%{_libexecdir}/shifter/shifter_slurm_dws_support
+%endif
+
+%if 0%{!?_without_systemd:1}
+%{__mkdir_p} $RPM_BUILD_ROOT%{_unitdir}
+%{__install} -m 0644 extra/systemd/shifter_imagegw.service $RPM_BUILD_ROOT%{_unitdir}/
+%{__install} -m 0644 extra/systemd/shifter_imagegw_worker@.service $RPM_BUILD_ROOT%{_unitdir}/
+%{__install} -m 0644 extra/systemd/shifter_imagegw_worker.target $RPM_BUILD_ROOT%{_unitdir}/
 %endif
 
 
@@ -163,7 +180,7 @@ getent group > %{_sysconfdir}/shifter_etc_files/group
 
 %files
 %defattr(-, root, root)
-%doc AUTHORS Dockerfile LICENSE NEWS README*
+%doc AUTHORS Dockerfile LICENSE NEWS README* doc extra/cle6
 
 %files runtime
 %defattr(-, root, root)
@@ -181,14 +198,18 @@ getent group > %{_sysconfdir}/shifter_etc_files/group
 
 %files imagegw
 %defattr(-, root, root)
-%doc AUTHORS LICENSE NEWS README*
+%doc AUTHORS LICENSE NEWS README* contrib extra/systemd
 %attr(0770, %{shifter_user}, %{shifter_group}) %dir %{_localstatedir}/log/%{name}_imagegw/
+%attr(0770, %{shifter_user}, %{shifter_group}) %dir %{_localstatedir}/log/%{name}_imagegw_worker/
 %{_libdir}/python2.*/site-packages/shifter_imagegw
 %{_libexecdir}/shifter/imagecli.py*
 %{_libexecdir}/shifter/imagegwapi.py*
 %{_libexecdir}/shifter/sitecustomize.py*
 %{_datadir}/shifter/requirements.txt
 %{_sysconfdir}/imagemanager.json.example
+%if 0%{!?_without_systemd:1}
+%{_unitdir}/shifter_imagegw*
+%endif
 
 %if 0%{?with_slurm:1}
 %files slurm

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -16,15 +16,15 @@ test_udiRoot.conf: test_udiRoot.conf.in
 	chmod 644 test_udiRoot.conf
 
 chroot1/nss:
-	./setup_test_chroot.sh chroot1
+	$(srcdir)/setup_test_chroot.sh chroot1
 	touch chroot1/nss
 
 chroot2/nss:
-	./setup_test_chroot.sh chroot2
+	$(srcdir)/setup_test_chroot.sh chroot2
 	touch chroot2/nss
 
 chroot3/nss:
-	./setup_test_chroot.sh chroot3
+	$(srcdir)/setup_test_chroot.sh chroot3
 	touch chroot3/nss
 
 
@@ -107,6 +107,7 @@ test_MountList_LDFLAGS = $(TEST_LDFLAGS)
 
 clean-local: clean-local-check
 clean-local-check:
+	-rm -rf chroot1 chroot2 chroot3
 	-rm -rf *.gcda
 	-rm -rf *.gcno
 	-rm -f test_udiRoot.conf 


### PR DESCRIPTION
These changes fix `make distcheck`, add arbitrary `./configure` flag support for `rpmbuild`, and add the `systemd` unit files, docs, etc. to the RPM packages, esp. for use on RHEL7.