### PR TITLE
Tarfile issues

### DIFF
--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -529,7 +529,8 @@ class DockerV2Handle(object):
 
             return [x for x in layer_members \
                     if (not x.name == to_remove
-                        and not x.name.startswith(prefix_to_remove))]
+                        and not x.name.startswith(prefix_to_remove)
+			and not x.isdev())]
 
         layer_paths = []
         tar_file_refs = []

--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -542,7 +542,7 @@ class DockerV2Handle(object):
 
             tfname = '%s.tar' % layer['fsLayer']['blobSum']
             tfname = os.path.join(cachedir, tfname)
-            tfp = tarfile.open(tfname, 'r:gz')
+            tfp = tarfile.open(tfname, 'r:gz', errorlevel=0)
             tar_file_refs.append(tfp)
 
             ## get directory of tar contents


### PR DESCRIPTION
Some dev device files where not properly excluded and the default error level for tarfile changed from python 2.6 to 2.7 making some extracts to fail