### PR TITLE
Fix workdir support

### DIFF
--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -434,6 +434,8 @@ class DockerV2Handle(object):
             config = meta['config']
             if 'Env' in config:
                 resp['env'] = config['Env']
+            if 'WorkingDir' in config:
+                resp['workdir'] = config['WorkingDir']
             if 'Entrypoint' in config:
                 resp['entrypoint'] = config['Entrypoint']
         resp['private'] = self.private
@@ -677,6 +679,8 @@ def pull_image(options, repo, tag, cachedir='./', expanddir='./'):
         config = meta['config']
         if 'Env' in config:
             resp['env'] = config['Env']
+        if 'WorkingDir' in config:
+            resp['workdir'] = config['WorkingDir']
         if 'Entrypoint' in config:
             resp['entrypoint'] = config['Entrypoint']
 
@@ -692,10 +696,6 @@ def main():
     cache_dir = os.environ['TMPDIR']
     pull_image({'baseUrl': 'https://registry-1.docker.io'}, 'scanon/shanetest',
                'latest', cachedir=cache_dir, expanddir=cache_dir)
-
-    pull_image({'baseUrl': 'https://registry-1.docker.io'},
-               'dlwoodruff/pyomodock', '4.3.1137', cachedir=cache_dir,
-               expanddir=cache_dir)
 
 if __name__ == '__main__':
     main()

--- a/imagegw/test/dockerv2_test.py
+++ b/imagegw/test/dockerv2_test.py
@@ -53,8 +53,6 @@ class Dockerv2TestCase(unittest.TestCase):
             path = os.path.join(resp['expandedpath'], loc)
             assert not os.path.exists(path)
 
-        return
-
     # This test case has files that in one layer are made non-writeable.
     # This requires fixing permissions on the parent layers before extraction.
     # This test uses a prepared image scanon/shanetest
@@ -69,11 +67,12 @@ class Dockerv2TestCase(unittest.TestCase):
 
         assert os.path.exists(resp['expandedpath'])
         bfile = os.path.join(resp['expandedpath'], 'tmp/b')
+        self.assertIn('workdir', resp)
+        assert os.path.exists(resp['expandedpath'])
         assert os.path.exists(bfile)
         with open(bfile) as f:
             data = f.read()
             assert(data == 'blah\n')
-        return
 
 
 if __name__ == '__main__':

--- a/imagegw/test/imagegwapi_test.py
+++ b/imagegw/test/imagegwapi_test.py
@@ -65,8 +65,6 @@ class GWTestCase(unittest.TestCase):
         self.auth_header = 'authentication'
         self.logfile = '/tmp/worker.log'
         self.pid = 0
-        #if os.path.exists(self.logfile):
-        #    os.unlink(self.logfile)
         self.start_worker()
 
     def tearDown(self):
@@ -80,7 +78,7 @@ class GWTestCase(unittest.TestCase):
             os.environ['TESTMODE'] = '%d' % (testmode)
             os.execvp('celery', ['celery', '-A', 'shifter_imagegw.imageworker',
                                  'worker', '--quiet', '-Q', '%s' % (system),
-                                 '--loglevel=INFO', '-c', '1',
+                                 '--loglevel=DEBUG', '-c', '1',
                                  '-f', self.logfile])
         else:
             self.pid = pid

--- a/imagegw/test/imagemngr_test.py
+++ b/imagegw/test/imagemngr_test.py
@@ -60,8 +60,6 @@ class ImageMngrTestCase(unittest.TestCase):
             pass  # os.unlink(self.logfile)
         # Cleanup Mongo
         self.images.remove({})
-        #if self.images.find_one(self.query):
-        #    self.images.remove(self.query)
 
     def tearDown(self):
         """
@@ -575,7 +573,7 @@ class ImageMngrTestCase(unittest.TestCase):
         assert '_id' in mrec
         # Track through transistions
         state = self.time_wait(id)
-        #Debug
+        # Debug
         assert state == 'READY'
         imagerec = self.m.lookup(session, pr)
         assert 'ENTRY' in imagerec
@@ -770,14 +768,14 @@ class ImageMngrTestCase(unittest.TestCase):
         mrec = self.images.find_one(q)
         assert '_id' in mrec
         assert 'userACL' in mrec
-        self.assertIn('workdir', mrec)
         assert 1001 in mrec['userACL']
         # Track through transistions
         state = self.time_wait(id)
         assert state == 'READY'
         mrec = self.images.find_one(q)
-        assert 'private' in mrec
-        assert mrec['private'] is False
+        self.assertIn('WORKDIR', mrec)
+        self.assertIn('private', mrec)
+        self.assertFalse(mrec['private'])
 
     def test_pull_public_acl_token(self):
         """
@@ -852,7 +850,7 @@ class ImageMngrTestCase(unittest.TestCase):
         self.assertIn(1001, mrec['userACL'])
         # Track through transistions
         state = self.time_wait(id)
-        #Debug
+        # Debug
         self.assertEquals(state, 'READY')
         imagerec = self.m.lookup(session, pr)
         assert 'ENTRY' in imagerec
@@ -1057,6 +1055,7 @@ class ImageMngrTestCase(unittest.TestCase):
         recs = self.m.get_metrics(session, self.system, 101)  # ,delay=False)
         self.assertIsNotNone(recs)
         self.assertEquals(len(recs), 100)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/imagegw/test/imagemngr_test.py
+++ b/imagegw/test/imagemngr_test.py
@@ -685,7 +685,6 @@ class ImageMngrTestCase(unittest.TestCase):
             'groupACL': [1003, 1004]
         }
         rec = self.m.pull(session, pr)  # ,delay=False)
-        print rec
         assert rec['status'] == 'PULLING'
 
     def test_pull_logic(self):
@@ -771,6 +770,7 @@ class ImageMngrTestCase(unittest.TestCase):
         mrec = self.images.find_one(q)
         assert '_id' in mrec
         assert 'userACL' in mrec
+        self.assertIn('workdir', mrec)
         assert 1001 in mrec['userACL']
         # Track through transistions
         state = self.time_wait(id)

--- a/imagegw/test/imageworker_test.py
+++ b/imagegw/test/imageworker_test.py
@@ -22,7 +22,8 @@ import json
 
 
 def update_status(state, meta=None):
-    print 'state=%s' % (state)
+    if 'SHOWSTATE' in os.environ:
+        print 'state=%s' % (state)
 
 
 class ImageWorkerTestCase(unittest.TestCase):
@@ -153,8 +154,8 @@ class ImageWorkerTestCase(unittest.TestCase):
             'tag': self.tag
         }
         status = self.imageworker.pull_image(request)
-        # TODO: a little odd that is True and == True used here
         self.assertTrue(status)
+        self.assertIn('expandedpath', request)
         status = self.imageworker.convert_image(request)
         self.assertTrue(status)
 

--- a/imagegw/test/imageworker_test.py
+++ b/imagegw/test/imageworker_test.py
@@ -19,6 +19,7 @@
 import os
 import unittest
 import json
+import shutil
 
 
 def update_status(state, meta=None):
@@ -37,34 +38,37 @@ class ImageWorkerTestCase(unittest.TestCase):
         self.configfile = 'test.json'
         with open(self.configfile) as config_file:
             self.config = json.load(config_file)
+
         self.system = 'systema'
         self.itype = 'docker'
         self.tag = 'registry.services.nersc.gov/nersc-py:latest'
         self.tag = 'ubuntu:latest'
         self.tag = 'scanon/shanetest:latest'
-        self.hash = \
-            'b3491cdefcdb79a31ab7ddf1bbcf7c8eeff9b4f00cb83a0be513fb800623f9cf'
-        self.hash2 = \
-            'a90493edb7d6589542c475ebfd052fe3912a153015d6e0923cfd5f40d0bc2925'
-        self.hash3 = \
-            'ac6b4960ac85aeb6effc8538955078fcb1f3bb9e15451efe63b753a3a566884c'
+        self.request = {
+                        'system': self.system,
+                        'itype': self.itype,
+                        'tag': self.tag
+        }
+        if 'LOCALREGISTRY' in os.environ:
+            self.config['DefaultImageLocation'] = 'local'
+            self.tag = 'local' + '/' + self.tag
         if not os.path.exists(self.config['CacheDirectory']):
             os.mkdir(self.config['CacheDirectory'])
         self.expandedpath = \
             os.path.join(self.config['CacheDirectory'],
                          '%s_%s' % (self.itype, self.tag.replace('/', '_')))
-        self.imagefile = os.path.join(self.config['ExpandDirectory'],
-                                      '%s.%s' % (self.hash, 'squashfs'))
         idir = self.config['Platforms']['systema']['ssh']['imageDir']
         if not os.path.exists(idir):
             os.makedirs(idir)
         self.imageDir = idir
 
     def cleanup_cache(self):
-        for h in [self.hash, self.hash2, self.hash3]:
-            fp = '%s/%s.meta' % (self.imageDir, h)
-            if os.path.exists(fp):
-                os.remove(fp)
+        paths = [self.imageDir, self.config['CacheDirectory']]
+        for path in paths:
+            for f in os.listdir(path):
+                if f.find('.squashfs') > 0 or f.find('.meta') > 0:
+                    fn = os.path.join(path, f)
+                    os.remove(fn)
 
     def get_metafile(self, id):
         metafile = os.path.join(self.imageDir, '%s.meta' % (id))
@@ -88,7 +92,7 @@ class ImageWorkerTestCase(unittest.TestCase):
 
     def test_pull_image_basic(self):
         self.cleanup_cache()
-        request = {'system': self.system, 'itype': self.itype, 'tag': self.tag}
+        request = self.request
         status = self.imageworker.pull_image(request)
         self.assertTrue(status)
         self.assertIn('meta', request)
@@ -102,11 +106,9 @@ class ImageWorkerTestCase(unittest.TestCase):
 
     # Pull the image but explicitly specify dockerhub
     def test_pull_image_dockerhub(self):
-        request = {
-            'system': self.system,
-            'itype': self.itype,
-            'tag': 'index.docker.io/ubuntu:latest'
-        }
+        self.cleanup_cache()
+        request = self.request
+        request['tag'] = 'index.docker.io/ubuntu:latest'
         status = self.imageworker.pull_image(request)
         self.assertTrue(status)
         self.assertIn('meta', request)
@@ -117,6 +119,7 @@ class ImageWorkerTestCase(unittest.TestCase):
 
     # Use the URL format of the location, like an alias
     def test_pull_image_url(self):
+        self.cleanup_cache()
         request = {
             'system': self.system,
             'itype': self.itype,
@@ -148,56 +151,48 @@ class ImageWorkerTestCase(unittest.TestCase):
         return
 
     def test_convert_image(self):
-        request = {
-            'system': self.system,
-            'itype': self.itype,
-            'tag': self.tag
-        }
-        status = self.imageworker.pull_image(request)
-        self.assertTrue(status)
-        self.assertIn('expandedpath', request)
+        # Create a bogus tree
+        self.cleanup_cache()
+        base = self.imageDir + '/image'
+        if os.path.exists(base):
+            shutil.rmtree(base)
+        os.makedirs('%s/%s' % (base, 'a/b/c'))
+        request = self.request
+        request['id'] = 'bogus'
+        request['expandedpath'] = base
         status = self.imageworker.convert_image(request)
         self.assertTrue(status)
+        # Cleanup
+        if os.path.exists(base):
+            shutil.rmtree(base)
 
     def test_transfer_image(self):
-        request = {
-            'system': self.system,
-            'itype': self.itype,
-            'tag': self.tag,
-            'imagefile': self.imagefile
-        }
-        with open(self.imagefile, 'w') as f:
+        hash = 'bogus'
+        imagefile = os.path.join(self.config['ExpandDirectory'],
+                                 '%s.%s' % (hash, 'squashfs'))
+        request = self.request
+        request['imagefile'] = imagefile
+        with open(imagefile, 'w') as f:
             f.write('bogus')
-        assert os.path.exists(self.imagefile)
+        self.assertTrue(os.path.exists(imagefile))
         status = self.imageworker.transfer_image(request)
         self.assertTrue(status)
 
     def test_pull_docker(self):
-        request = {
-            'system': self.system,
-            'itype': self.itype,
-            'tag': self.tag
-        }
+        self.cleanup_cache()
+        request = self.request
         resp = self.imageworker._pull_dockerv2(request, 'index.docker.io',
                                                'scanon/shanetest', 'latest',
                                                self.updater)
         self.assertTrue(resp)
 
     def test_pull_image(self):
-        request = {
-            'system': self.system,
-            'itype': self.itype,
-            'tag': self.tag
-        }
+        request = self.request
         resp = self.imageworker.pull_image(request, self.updater)
         self.assertTrue(resp)
 
     def test_puller_testmode(self):
-        request = {
-            'system': self.system,
-            'itype': self.itype,
-            'tag': self.tag
-        }
+        request = self.request
         result = self.imageworker.pull(request, self.updater, testmode=1)
         self.assertIn('workdir', result)
         self.assertIn('env', result)
@@ -206,12 +201,7 @@ class ImageWorkerTestCase(unittest.TestCase):
             self.imageworker.pull(request, self.updater, testmode=2)
 
     def test_puller_real(self):
-        request = {
-            'system': self.system,
-            'itype': self.itype,
-            'tag': self.tag
-        }
-
+        request = self.request
         result = self.imageworker.pull(request, self.updater)
         mf = self.get_metafile(result['id'])
         mfdata = self.read_metafile(mf)
@@ -219,9 +209,6 @@ class ImageWorkerTestCase(unittest.TestCase):
         request['userACL'] = [1001]
         result = self.imageworker.pull(request, self.updater)
         self.imageworker.remove_image(request)
-
-    def test_unimplemented_fuctions(self):
-        pass
 
 
 if __name__ == '__main__':

--- a/src/shifter.c
+++ b/src/shifter.c
@@ -188,10 +188,10 @@ int main(int argc, char **argv) {
 
         if (entry != NULL) {
             opts.args[0] = strdup(entry);
-            if (imageData.workdir != NULL) {
-                opts.workdir = strdup(imageData.workdir);
-            }
         }
+    }
+    if (imageData.workdir != NULL && opts.workdir == NULL) {
+        opts.workdir = strdup(imageData.workdir);
     }
 
     snprintf(udiRoot, PATH_MAX, "%s", udiConfig.udiMountPoint);
@@ -404,6 +404,7 @@ int parse_options(int argc, char **argv, struct options *config, UdiRootConfig *
         {"verbose", 0, 0, 'v'},
         {"image", 1, 0, 'i'},
         {"entrypoint", 2, 0, 0},
+        {"workdir", 1, 0, 'w'},
         {"env", 0, 0, 'e'},
         {0, 0, 0, 0}
     };
@@ -422,7 +423,7 @@ int parse_options(int argc, char **argv, struct options *config, UdiRootConfig *
     optind = 1;
     for ( ; ; ) {
         int longopt_index = 0;
-        opt = getopt_long(argc, argv, "hnvV:i:e:", long_options, &longopt_index);
+        opt = getopt_long(argc, argv, "hnvV:i:e:w:", long_options, &longopt_index);
         if (opt == -1) break;
 
         switch (opt) {
@@ -434,6 +435,11 @@ int parse_options(int argc, char **argv, struct options *config, UdiRootConfig *
                             config->entrypoint = strdup(optarg);
                         }
                     }
+                }
+                break;
+            case 'w':
+                if (optarg != NULL) {
+                    config->workdir = strdup(optarg);
                 }
                 break;
             case 'v':


### PR DESCRIPTION
This fixes support for workdir support.  It fixes capture the workdir
in the metadata, saving it in the metafile, and have the shifter tool
use it even if not using --entry.