### PR TITLE
Enhance specfile BuildRequires for mock/nspawn

### DIFF
--- a/shifter.spec
+++ b/shifter.spec
@@ -46,7 +46,7 @@ Shifter, please install the "shifter-runtime" package.
 Summary:  Runtime component(s) for NERSC Shifter (formerly udiRoot)
 Group:    System Environment/Base
 %if 0%{?suse_version}
-BuildRequires: munge, libcurl-devel, libjson-c-devel, pam-devel, libcap-devel
+BuildRequires: munge, libcurl-devel, libjson-c-devel, pam-devel, libcap-devel, python
 %else
 BuildRequires: munge-devel, gcc, gcc-c++
 BuildRequires: libtool autoconf automake
@@ -54,6 +54,7 @@ BuildRequires: libcurl libcurl-devel
 BuildRequires: json-c json-c-devel
 BuildRequires: pam-devel
 BuildRequires: libcap-devel
+BuildRequires: python
 %endif
 
 %description runtime
@@ -102,6 +103,7 @@ use with Shifter.
 %package slurm
 Summary:  SLURM Spank Module for Shifter
 BuildRequires: slurm-devel
+BuildRequires: xfsprogs
 
 %description slurm
 Shifter enables container images for HPC. In a nutshell, Shifter


### PR DESCRIPTION
When building shifter rpms with mock in a minimalistic environment, some build requirements are missing.