### PR TITLE
Fix slurm 17.11

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+16.08.5
+==========
+* Update slurm integration to update for Slurm CVE-2017-15566
+* Properly exit in slurm integration when dlopen() for libslurm.so fails
+
 16.08.3
 ==========
 * Perform volume mount realpath() and lstat() verfication with user privileges,

--- a/shifter.spec
+++ b/shifter.spec
@@ -17,7 +17,7 @@
 
 Summary:   NERSC Shifter -- Containers for HPC
 Name:      shifter
-Version:   16.08.3
+Version:   16.08.5
 Release:   1.nersc%{?dist}
 License:   BSD (LBNL-modified)
 Group:     System Environment/Base

--- a/wlm_integration/slurm/shifterSpank.c
+++ b/wlm_integration/slurm/shifterSpank.c
@@ -255,12 +255,9 @@ int shifterSpank_process_option_volume(
         }
         free_VolumeMap(vmap, 1);
         if (ssconfig->volume != NULL) {
-            char *tmpvol = alloc_strgenf("%s;%s", ssconfig->volume, optarg);
             free(ssconfig->volume);
-            ssconfig->volume = tmpvol;
-        } else {
-            ssconfig->volume = strdup(optarg);
         }
+        ssconfig->volume = strdup(optarg);
 
         return SUCCESS;
     }


### PR DESCRIPTION
slurm 17.11 spank requires that spank option processing be able to be run multiple times.  the old logic unnecessarily appended volume mounts to the internal option data structure.  the new logic replaces.  This should be appropriate for all versions of slurm.

the change is being tested on gerty presently.