### PR TITLE
add flag to always install the gcc wrapper, this is important to allo…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,7 @@
 * Minor fixes for RPM builds
 * Improved image unpacking for some edge cases
 * Dropped celery dependency to simplify installation
+* Updated support for Slurm 17.11
 * Reduced help output in most error conditions (it was rather verbose)
 * Memory management improvements
 * Remove kernel module loading support

--- a/dep/build_ssh.sh
+++ b/dep/build_ssh.sh
@@ -51,7 +51,7 @@ fi
 mkdir -p musl
 tar xf "musl-${MUSL_VERSION}.tar.gz" -C musl --strip-components=1
 cd musl
-./configure "--prefix=${SPRT_PREFIX}" --enable-static --disable-shared
+./configure "--prefix=${SPRT_PREFIX}" --enable-static --disable-shared --enable-gcc-wrapper
 make
 make install
 cd "${builddir}"

--- a/wlm_integration/slurm/test/Makefile.am
+++ b/wlm_integration/slurm/test/Makefile.am
@@ -29,7 +29,8 @@ test_shifterSpank_config_SOURCES = \
     $(top_srcdir)/src/ImageData.c \
     $(top_srcdir)/src/shifter_core.c \
     $(top_srcdir)/src/PathList.c \
-    $(top_srcdir)/src/MountList.c
+    $(top_srcdir)/src/MountList.c \
+    $(top_srcdir)/src/shifter_mem.c
 test_shifterSpank_config_CXXFLAGS = $(TEST_CFLAGS)
 test_shifterSpank_config_CFLAGS = $(TEST_CFLAGS)
 test_shifterSpank_config_LDFLAGS = $(TEST_LDFLAGS)
@@ -44,7 +45,8 @@ test_shifterSpank_util_SOURCES = \
     $(top_srcdir)/src/ImageData.c \
     $(top_srcdir)/src/shifter_core.c \
     $(top_srcdir)/src/PathList.c \
-    $(top_srcdir)/src/MountList.c
+    $(top_srcdir)/src/MountList.c \
+    $(top_srcdir)/src/shifter_mem.c
 test_shifterSpank_util_CXXFLAGS = $(TEST_CFLAGS)
 test_shifterSpank_util_CFLAGS = $(TEST_CFLAGS)
 test_shifterSpank_util_LDFLAGS = $(TEST_LDFLAGS)
@@ -59,7 +61,8 @@ test_shifterSpank_prolog_SOURCES = \
     $(top_srcdir)/src/ImageData.c \
     $(top_srcdir)/src/shifter_core.c \
     $(top_srcdir)/src/PathList.c \
-    $(top_srcdir)/src/MountList.c
+    $(top_srcdir)/src/MountList.c \
+    $(top_srcdir)/src/shifter_mem.c
 test_shifterSpank_prolog_CXXFLAGS = $(TEST_CFLAGS)
 test_shifterSpank_prolog_CFLAGS = $(TEST_CFLAGS)
 test_shifterSpank_prolog_LDFLAGS = $(TEST_LDFLAGS)
@@ -74,7 +77,8 @@ test_shifterSpank_cgroup_SOURCES = \
     $(top_srcdir)/src/ImageData.c \
     $(top_srcdir)/src/shifter_core.c \
     $(top_srcdir)/src/PathList.c \
-    $(top_srcdir)/src/MountList.c
+    $(top_srcdir)/src/MountList.c \
+    $(top_srcdir)/src/shifter_mem.c
 test_shifterSpank_cgroup_CXXFLAGS = $(TEST_CFLAGS)
 test_shifterSpank_cgroup_CFLAGS = $(TEST_CFLAGS)
 test_shifterSpank_cgroup_LDFLAGS = $(TEST_LDFLAGS)


### PR DESCRIPTION
…w the build_ssh.sh script towork on fedora