### PR TITLE
Fix dockerv2 token authorization with multiple permissions

### DIFF
--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -373,7 +373,7 @@ class DockerV2Handle(object):
         (_, auth_data_str) = auth_loc_str.split(' ', 2)
 
         auth_data = {}
-        for item in auth_data_str.split(','):
+        for item in filter(None, re.split(r'(\w+=".*?"),', auth_data_str)):
             (key, val) = item.split('=', 2)
             auth_data[key] = val.replace('"', '')
 


### PR DESCRIPTION
If WWW-Authenticate header of manifest endpoint contains multiple
scope permissions (e.g. pull and push), they are specified separated by
a comma, see https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate.
Such API response causes `need more than 1 value to unpack` error due to the current string
split implementation, therefore auth_data_str split logic should be more strict.

Fixes https://github.com/NERSC/shifter/issues/236.