### PR TITLE
Fix for Issue #244

### DIFF
--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -626,6 +626,10 @@ class DockerV2Handle(object):
             members = filter_layer(members, 'dev/')
             members = filter_layer(members, '/')
             members = [x for x in members if not x.name.find('..') >= 0]
+            for x in members:
+                 if x.name[0:2] == './':
+                     x.name=x.name[2:]
+
 
             # find all whiteouts
             whiteouts = [x for x in members

--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -622,14 +622,14 @@ class DockerV2Handle(object):
             # get directory of tar contents
             members = tfp.getmembers()
 
+            # Normalize paths
+            for x in members:
+                if x.name[0:2] == './':
+                    x.name = x.name[2:]
             # remove all illegal files
             members = filter_layer(members, 'dev/')
             members = filter_layer(members, '/')
             members = [x for x in members if not x.name.find('..') >= 0]
-            for x in members:
-                 if x.name[0:2] == './':
-                     x.name=x.name[2:]
-
 
             # find all whiteouts
             whiteouts = [x for x in members

--- a/imagegw/test/dockerv2_test.py
+++ b/imagegw/test/dockerv2_test.py
@@ -105,6 +105,18 @@ class Dockerv2TestCase(unittest.TestCase):
         bfile = os.path.join(resp['expandedpath'], 'build/test2')
         assert os.path.exists(bfile)
 
+    def test_import(self):
+        cache = tempfile.mkdtemp()
+        expand = tempfile.mkdtemp()
+        self.cleanpaths.append(cache)
+        self.cleanpaths.append(expand)
+
+        resp = dockerv2.pull_image(self.options, 'scanon/importtest', 'latest',
+                                   cachedir=cache, expanddir=expand)
+        assert os.path.exists(resp['expandedpath'])
+        bfile = os.path.join(resp['expandedpath'], 'home')
+        self.assertTrue(os.path.islink(bfile))
+
     def test_need_proxy(self):
         """
         Test if proxy is needed


### PR DESCRIPTION
Imported images have an extra './' in the tar file paths.  If a later
layer that builds on that import changes a directory to a file or link,
the paths will be different.  So this normalizes the paths across all the
layers by stripping off any './' prefix.

It adds a test too.

Closes issue #244 