### PR TITLE
Fix for queue list

### DIFF
--- a/imagegw/shifter_imagegw/imagemngr.py
+++ b/imagegw/shifter_imagegw/imagemngr.py
@@ -393,6 +393,10 @@ class ImageMngr(object):
         records = self._images_find(query)
         resp = []
         for record in records:
+            if 'pulltag' not in record:
+                continue
+            if record['status'] == 'EXPIRED':
+                continue
             resp.append({'status': record['status'],
                         'image': record['pulltag']})
         return resp


### PR DESCRIPTION
This fixes #268.  Some older records may be missing the pulltag
key.  This ignores those in the queue list.