### PR TITLE
Build shifter_cray_mpich libraries into an RPM

### DIFF
--- a/doc/install/cle6.rst
+++ b/doc/install/cle6.rst
@@ -56,15 +56,26 @@ to the container environment.
    the %libexec% path if shifter-runtime RPM is used).
 
    """
-   mkdir -p /tmp/cray/lib64
-   python /path/to/extra/prep_cray_mpi_libs.py /tmp/cray/lib64
+   mkdir -p /tmp/cray
+   cd /path/to/shifter/extra
+   python ./prep_cray_mpi_libs.py /tmp/cray
    """
 
-   Copy /tmp/cray to a path within the udiImage directory (by default
-   /usr/lib/shifter/opt/udiImage)
-3. To automate override of libmpi.so modify siteEnvAppend to add:
-      LD_LIBRARY_PATH=/opt/udiImage/cray/lib64
+   You can then either copy /tmp/cray/mpich-<version> to
+   /usr/lib/shifter/opt/mpich-<version> or integrate the RPM in
+   /tmp/cray/RPMS/x86_64/shifter_cray_mpich_<version>....rpm into your
+   compute and login images.
+3. Setup a shifter module to setup cray mpich by adding the following to
+   your udiRoot.conf:
 
+       module_mpich_copyPath = /usr/lib/shifter/opt/mpich-<version>
+       module_mpich_siteEnvPrepend = LD_LIBRARY_PATH=/opt/udiImage/modules/mpich/lib64
+       module_mpich_siteEnv = SHIFTER_MODULE_MPICH=1
+
+4. If you wish the mpich module to load by default on every shifter invocation,
+   then add the following to your udiRoot.conf:
+
+       defaultModules = mpich
 
 prep_cray_mpi_libs.py copies the shared libraries from the CrayPE cray-mpich
 and cray-mpich-abi modules (for both PrgEnv-gnu and PrgEnv-intel), into the

--- a/doc/mpi/mpich_abi.rst
+++ b/doc/mpi/mpich_abi.rst
@@ -114,13 +114,13 @@ Note: in CLE5.2 this should be done on an internal login node; in CLE6 an
 internal or external login node should work. You'll need to install patchelf
 into your PATH prior to running (https://nixos.org/patchelf.html)
 
-Next copy /tmp/craylibs to your shifter module path (see Modules) under
-mpich/lib64, e.g., :code:`/usr/lib/shifter/modules/mpich/lib64`.
+Next copy /tmp/craylibs/mpich-<version> to your shifter module path (see Modules):
+e.g., :code:`/usr/lib/shifter/opt/mpich-<version>`.
 
 Finally, a few modifications need to be made to udiRoot.conf:
 
 1. add "module_mpich_siteEnvPrepend = LD_LIBRARY_PATH=/opt/udiImage/modules/mpich/lib64"
-2. add "module_mpich_copyPath = /usr/lib/shifter/modules/mpich"
+2. add "module_mpich_copyPath = /usr/lib/shifter/opt/mpich-<version>"
 3. add "/var/opt/cray/alps:/var/opt/cray/alps:rec" to siteFs
 4. if CLE6, add "/etc/opt/cray/wlm_detect:/etc/opt/cray/wlm_detect" to siteFs
 5. add "defaultModules = mpich" to load cray-mpich support by default in all containers

--- a/extra/prep_cray_mpi_libs.py
+++ b/extra/prep_cray_mpi_libs.py
@@ -239,12 +239,15 @@ def main():
         print "Failed to find patchelf command.  Please get patchelf into PATH before proceeding"
         sys.exit(1)
 
-    if len(sys.argv) != 2:
+    if len(sys.argv) < 2:
         print "No destination path specified"
         sys.exit(1)
 
 
     copy_tgt_path = sys.argv[1]
+    module_name = 'mpich'
+    if len(sys.argv) > 2:
+        module_name = sys.argv[2]
 
     ## only consider current cray/system modules
     fix_module_path()
@@ -285,9 +288,13 @@ def main():
     os.mkdir(copy_tgt_path)
     copy_path = os.path.join(copy_tgt_path, "mpich-%s" % mpich_version)
     os.mkdir(copy_path)
+    copy_path = os.path.join(copy_path, 'lib64')
+    os.mkdir(copy_path)
     os.mkdir('%s/%s' % (copy_path, 'dep'))
 
-    dest_tgt_path = '/opt/udiImage/modules/mpich-%s/lib64' % mpich_version
+    if not module_name:
+        module_name = 'mpich'
+    dest_tgt_path = '/opt/udiImage/modules/%s/lib64' % module_name
     dest_tgt_dep_path = '%s/%s' % (dest_tgt_path, 'dep')
 
 

--- a/extra/shifter_cray_mpich.spec.in
+++ b/extra/shifter_cray_mpich.spec.in
@@ -20,7 +20,7 @@
 Name:           shifter_cray_mpich_%{cray_mpich_version}
 Version:        %{cray_mpich_version}
 Release:        1
-Summary:	cray cle6 mpich Binaries relocated for shifter's use
+Summary:	cray mpich Binaries relocated for shifter's use
 Source:         shifter-cray-mpich-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 License:        Proprietary
@@ -42,6 +42,7 @@ mv * "$RPM_BUILD_ROOT/usr/lib/shifter/opt/mpich-%{cray_mpich_version}/"
 %postun
 
 %files
+%dir /usr/lib/shifter/opt/mpich-%{cray_mpich_version}
 /usr/lib/shifter/opt/mpich-%{cray_mpich_version}/*
 
 %changelog

--- a/extra/shifter_cray_mpich.spec.in
+++ b/extra/shifter_cray_mpich.spec.in
@@ -1,0 +1,48 @@
+#
+# spec file for package shifter_cray_mpich
+#
+# Copyright (c) 2020 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+%define cray_mpich_version {{CRAY_MPICH_VERSION}}
+
+Name:           shifter_cray_mpich_%{cray_mpich_version}
+Version:        %{cray_mpich_version}
+Release:        1
+Summary:	cray cle6 mpich Binaries relocated for shifter's use
+Source:         shifter-cray-mpich-%{version}.tar.gz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+License:        Proprietary
+AutoReq: 0
+AutoProv: 0
+
+%description
+
+%prep
+%setup -q -n mpich-%{version}
+
+%build
+
+%install
+mkdir -p "$RPM_BUILD_ROOT/usr/lib/shifter/opt/mpich-%{cray_mpich_version}"
+mv * "$RPM_BUILD_ROOT/usr/lib/shifter/opt/mpich-%{cray_mpich_version}/"
+
+%post
+%postun
+
+%files
+/usr/lib/shifter/opt/mpich-%{cray_mpich_version}/*
+
+%changelog
+


### PR DESCRIPTION
This automates the construction of an RPM that can be  integrated into a CLE image to ease distribution of shifter-prepared cray-mpich libraries, and optimizes the performance of the availability of these libraries to compute nodes as a result.

Commits d5494a4 and 8c84a27 are the key commits here.  I also performed some pylint-reccommended cleanups in between (sorry about that).

In addition to constructing an RPM, these changes:
* move the RPMs from the argument-specified destination to append "/lib64" which was a required manual transformation before
* allow a new argument to change the shifter module name to be used (useful for specifying that it should be something other than mpich, perhaps mpich-cle6)