### PR TITLE
Unpacking and cleanup issues due to weird permissions

### DIFF
--- a/imagegw/shifter_imagegw/converters.py
+++ b/imagegw/shifter_imagegw/converters.py
@@ -27,7 +27,7 @@ import os
 import subprocess
 import shutil
 import tempfile
-from shifter_imagegw.util import program_exists
+from shifter_imagegw.util import program_exists, rmtree
 
 
 def generate_ext4_image(expand_path, image_path, options):
@@ -52,7 +52,7 @@ def generate_cramfs_image(expand_path, image_path, options):
         # error handling
         pass
     try:
-        shutil.rmtree(expand_path)
+        rmtree(expand_path)
     except:
         # error handling
         pass
@@ -79,7 +79,7 @@ def generate_squashfs_image(expand_path, image_path, options):
         # error handling
         pass
     try:
-        shutil.rmtree(expand_path)
+        rmtree(expand_path)
     except:
         pass
 

--- a/imagegw/shifter_imagegw/dockerv2_ext.py
+++ b/imagegw/shifter_imagegw/dockerv2_ext.py
@@ -23,6 +23,7 @@ includes pulling down the manifest, pulling layers, and unpacking the layers.
 
 import json
 import os
+import stat
 from subprocess import Popen, PIPE
 import base64
 import tempfile
@@ -226,6 +227,8 @@ class DockerV2ext(object):
             return False
         rootfs = os.path.join(idir, 'rootfs')
         os.rmdir(base_path)
-        shutil.move(rootfs, base_path)
+        perm = os.stat(rootfs).st_mode
+        os.chmod(rootfs, perm|stat.S_IEXEC|stat.S_IWRITE|stat.S_IREAD)
+        os.rename(rootfs, base_path)
         shutil.rmtree(idir)
         return True

--- a/imagegw/shifter_imagegw/util.py
+++ b/imagegw/shifter_imagegw/util.py
@@ -28,6 +28,8 @@
 """
 
 import os
+import stat
+import shutil
 
 
 def program_exists(program):
@@ -71,3 +73,14 @@ def which(program):
                     return candidate
 
     return None
+
+def rmtree(path):
+    def remove_readonly(func, path, _):
+        "Clear the readonly bit and reattempt the removal"
+        parent = os.path.dirname(path)
+        os.chmod(parent, stat.S_IRWXU)
+        if not os.path.islink(path):
+            os.chmod(path, stat.S_IRWXU)
+        func(path)
+
+    shutil.rmtree(path, onerror=remove_readonly)

--- a/imagegw/test/oci-image-tool
+++ b/imagegw/test/oci-image-tool
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 # Mock oci image tool (just exit without an error)
+exit 0


### PR DESCRIPTION
This fixes a bug when trying to unpack an image
that has weird permissions such as non-writeable
directories by the owner.  It also fixes some
cleanup for those same kinds of cases.