### PR TITLE
Remove autoclear option from squashfs mount

### DIFF
--- a/src/shifter_core.c
+++ b/src/shifter_core.c
@@ -1428,7 +1428,7 @@ int loopMount(const char *imagePath, const char *loopMountPath, ImageFormat form
             fprintf(stderr, "ERROR: no apparent support for squashfs!");
             goto _loopMount_unclean;
         }
-        useAutoclear = 1;
+        useAutoclear = 0;
         ready = 1;
         imgType = "squashfs";
     } else if (format == FORMAT_XFS) {


### PR DESCRIPTION
Unless I'm missing something, it seems like it's not supported in the new kernels.

Without this patch I'm getting "Unknown parameter autoclear" in dmesg when attempting to mount squashfs image.
I think old kernels might have just ignored unsupported options.