### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,58 +4,82 @@
 #        It runs munge and sshd which would normally be a bad idea for a container.
 #
 #        If you are looking to build an image for the gateway.  Look at the Dockerfile
-#        in imagegw/src.
+#        in the 'imagegw' directory.
 
 FROM ubuntu:14.04
-MAINTAINER Shane Canon <scanon@lbl.gov>
+
+LABEL name="Shifter"
+LABEL version="18.03"
+LABEL maintainer="scanon@lbl.gov"
 
 # Thanks to Sven Dowideit <SvenDowideit@docker.com>
 # for a Dockerfile that configured ssh
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install requirements to build shifter, run munge, and openssh
-RUN apt-get update && \
-       apt-get install -y gcc autoconf make libtool g++ munge libmunge-dev  \
-       libcurl4-openssl-dev libjson-c-dev build-essential openssh-server libcap-dev \
-    curl && \
-    mkdir /var/run/sshd && \
-    echo 'root:lookatmenow' | chpasswd && \
-    sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
-    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
-    echo "export VISIBLE=now" >> /etc/profile
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        curl \
+        g++ \
+        gcc \
+        libcap-dev \
+        libcurl4-openssl-dev \
+        libjson-c-dev \
+        libmunge-dev \
+        libtool \
+        make \
+        munge \
+        openssh-server \
+        python2.7 \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /var/run/sshd \
+    && echo 'root:lookatmenow' | chpasswd \
+    && sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
+    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+    && echo "export VISIBLE=now" >> /etc/profile
 
 ENV NOTVISIBLE "in users profile"
 
 ADD . /src/
 
-RUN \
-       cd /src/ && \
-       cp /bin/mount /src/dep/mount && \
-       touch configure.ac && \
-       sh ./autogen.sh && \
-       tar cf /src/dep/udiRoot_dep.tar /bin/mount && \
-       ./configure --prefix=/opt/shifter/udiRoot/1.0 --sysconfdir=/etc/shifter  \
-           --with-libcurl --with-munge --disable-nativeSlurm --disable-staticsshd && \
-       make && make install
+RUN cd /src/ \
+    && cp /bin/mount /src/dep/mount \
+    && touch configure.ac \
+    && sh ./autogen.sh \
+    && tar cf /src/dep/udiRoot_dep.tar /bin/mount \
+    && ./configure \
+        --prefix=/opt/shifter/udiRoot/1.0 \
+        --sysconfdir=/etc/shifter \
+        --with-libcurl \
+        --with-munge \
+        --disable-nativeSlurm \
+        --disable-staticsshd \
+    && make \
+    && make install
 
 ADD imagegw/test/entrypoint.sh /entrypoint.sh
 
 # Fix up perms and other things
-RUN \
-    mkdir /root/.ssh && chmod 700 /root/.ssh && \
-    echo "   StrictHostKeyChecking no" >> /etc/ssh/ssh_config && \
-    chmod 755 /var/log/ && \
-    echo 'PATH=$PATH:/opt/shifter/udiRoot/1.0/bin/' > /etc/profile.d/shifter.sh && \
-    chmod 755 /etc/profile.d/shifter.sh
+RUN mkdir /root/.ssh \
+    && chmod 700 /root/.ssh \
+    && echo "   StrictHostKeyChecking no" >> /etc/ssh/ssh_config \
+    && chmod 755 /var/log/ \
+    && echo 'PATH=$PATH:/opt/shifter/udiRoot/1.0/bin/' > /etc/profile.d/shifter.sh \
+    && chmod 755 /etc/profile.d/shifter.sh
 
 #    chmod 600 /etc/munge/munge.key && chown munge /etc/munge/munge.key && \
 
 ADD ./imagegw/test/premount.sh /etc/shifter/premount.sh
 ADD ./imagegw/test/postmount.sh /etc/shifter/postmount.sh
-RUN mkdir -p /images/test/
 ADD ./imagegw/test/test.squashfs /images/test
 COPY ./imagegw/shifter_imagegw/fasthash.py /usr/local/bin
 RUN chmod a+rx /usr/local/bin/fasthash.py
-
 
 EXPOSE 22
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM ubuntu:14.04
 
 LABEL name="Shifter"
 LABEL version="18.03"
-LABEL maintainer="scanon@lbl.gov"
+LABEL maintainer="Shane Canon <scanon@lbl.gov>"
 
 # Thanks to Sven Dowideit <SvenDowideit@docker.com>
 # for a Dockerfile that configured ssh

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ AC_PATH_PROG([INSMOD_PATH], [insmod], [NotFound], [$PATH$PATH_SEPARATOR/sbin$PAT
 AC_ARG_VAR([MODPROBE_PATH], [Path to modprobe executable])
 AC_PATH_PROG([MODPROBE_PATH], [modprobe], [NotFound], [$PATH$PATH_SEPARATOR/sbin$PATH_SEPARATOR/usr/sbin])
 
+m4_define_default([_AM_PYTHON_INTERPRETER_LIST],[python2.7 python2.6 python2])
 AM_PATH_PYTHON
 
 AC_ARG_ENABLE([cray], AS_HELP_STRING([--enable-cray], [Turn on cray support and testing options]))


### PR DESCRIPTION
Dockerfile:

  - set `name`, `version`, and `maintainer` labels
  - set `DEBIAN_FRONTEND` to `noninteractive`
  - use `--no-install-recommends` flag for `apt-get install`
  - sort installed packages alphabetically
  - add `automake` and `python2.7` packages
  - properly clean up apt's cache
  - move `&&`s to the beginning of lines for consistency
  - Remove unnecessary `mkdir -p /images/test/`

configure.ac:
  - Limit allowed Python versions to 2.7, 2.6, and 2.