### PR TITLE
Enable Sphinx 'todo' extension. Update documentation for the shifter command

### DIFF
--- a/doc/command/shifter.rst
+++ b/doc/command/shifter.rst
@@ -1,57 +1,66 @@
-shifter
-=======
+.. _shifter-command:
+
+``shifter`` command
+===================
 
 Synopsis
 --------
-*shifter* [options] _command_ [command options]
+*shifter* [options] *command* [command options]
 
 Description
 -----------
-*shifter* generates or attaches to an existing shifter container environment
+``shifter`` command generates or attaches to an existing Shifter container environment
 and launches a process within that container environment.  This is done with
 minimal overhead to ensure that container creation and process execution are
 done as quickly as possible in support of High Performance Computing needs.
 
 Options
 -------
---image       Image Selection Specification
--V|--volume   Volume bind mount
--h|--help     This help text
--v|--verbose  Increased logging output
+
+``-i`` \| ``--image``
+   Image selection specification
+``-V`` \| ``--volume``
+   Volume bind mount
+``-h`` \| ``--help``
+   This help text
+``-v`` \| ``--verbose``
+   Increased logging output
 
 Image Selection
 ---------------
-*shifter* identifies the desired image by examining its environment and command
+Shifter identifies the desired image by examining its environment and command
 line options.  In order of precedence, shifter selects image by looking at the
 following sources:
-   - SHIFTER environment variable containing both image type and image speicifier
-   - SHIFTER_IMAGE and SHIFTER_IMAGETYPE environment variables
-   - SLURM_SPANK_SHIFTER_IMAGE and SLURM_SPANK_SHIFTER_IMAGETYPE environment variables
-   - --image command line option
+   - ``SHIFTER`` environment variable containing both image type and image speicifier
+   - ``SHIFTER_IMAGE`` and ``SHIFTER_IMAGETYPE`` environment variables
+   - ``SLURM_SPANK_SHIFTER_IMAGE`` and ``SLURM_SPANK_SHIFTER_IMAGETYPE`` environment variables
+   - ``--image`` command line option
 
 Thus, the batch system can set effective defaults for image selection by manipulating
-the job environemnt, however, the user can always override by specifying the --image
+the job environemnt, however, the user can always override by specifying the ``--image``
 command line argument.
 
-The format of --image or the SHIFTER environment variable are the same:
+The format of ``--image`` or the ``SHIFTER`` environment variable are the same::
+
    imageType:imageSpecifier
 
-where imageType is typically "docker" but could be other, site-defined types.
-imageSpecifier is somewhat dependent on the imageType, however, for docker, the
+where ``imageType`` is typically ``docker`` but could be other, site-defined types.
+``imageSpecifier`` is somewhat dependent on the ``imageType``, however, for ``docker``, the
 image gateway typically assigns the sha256 hash of the image manifest to be
 the specifier.
 
-shifter will attempt to see if the global environment already has a shifter
+Shifter will attempt to see if the global environment already has a Shifter
 image configured matching the users arguments.  If a compatible image is already
 setup on the system the existing environment will be used to launch the 
-requested process.  If not, shifter will generate a new mount namespace, and
-setup a new shifter environment.  This ensures that multiple shifter instances
-can be used simultaneously on the same node.  Note that each shifter instance
+requested process.  If not, Shifter will generate a new mount namespace, and
+setup a new shifter environment.  This ensures that multiple Shifter instances
+can be used simultaneously on the same node.  Note that each Shifter instance
 will consume at least one loop device, thus it is recommended that sites allow
-for at least two available loop devices per shifter instance that might be
+for at least two available loop devices per Shifter instance that might be
 reasonably started on a compute node.  At NERSC, we allow up to 128 loop
 devices per compute node.
 
 User-Specified Volume Mounts
 ----------------------------
 
+.. todo:: Add documendation for user-specified volume mounts.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -28,7 +28,7 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['sphinx.ext.todo']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -101,7 +101,7 @@ pygments_style = 'sphinx'
 #keep_warnings = False
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = False
+todo_include_todos = True
 
 
 # -- Options for HTML output ----------------------------------------------


### PR DESCRIPTION
* doc/command/shifter.rst: A formatting update to make sure things are displayed correctly.
* doc/conf.py: enable 'todo' extension.