### PR TITLE
Add '@' to allowed characters

### DIFF
--- a/src/ImageData.c
+++ b/src/ImageData.c
@@ -498,7 +498,8 @@ char *_ImageData_filterString(const char *input, int allowSlash) {
     rptr = input;
     wptr = ret;
     while (wptr - ret < len && *rptr != 0) {
-        if (isalnum(*rptr) || *rptr == '_' || *rptr == ':' || *rptr == '.' || *rptr == '+' || *rptr == '-') {
+        if (isalnum(*rptr) || *rptr == '_' || *rptr == ':' || *rptr == '.' || \
+                              *rptr == '+' || *rptr == '-' || *rptr == '@' ) {
             *wptr++ = *rptr;
         }
         if (allowSlash && *rptr == '/') {


### PR DESCRIPTION
To do the lookup by hash we need to allow '@'.  I can't think of
a reason this would be unsafe.