### PR TITLE
Fix Cmd support and json detection

### DIFF
--- a/imagegw/requirements.txt
+++ b/imagegw/requirements.txt
@@ -1,3 +1,3 @@
-pymongo
+pymongo==3.12.1
 sanic==20.9.1
 pylint

--- a/imagegw/shifter_imagegw/converters.py
+++ b/imagegw/shifter_imagegw/converters.py
@@ -149,9 +149,11 @@ def writemeta(fmt, meta, metafile):
         if 'DISABLE_ACL_METADATA' in os.environ:
             private = False
         meta_fd.write("FORMAT: %s\n" % (fmt))
-        if 'entrypoint' in meta and meta['entrypoint'] is not None:
+        if meta.get('entrypoint'):
             meta_fd.write("ENTRY: %s\n" % (meta['entrypoint']))
-        if 'workdir' in meta and meta['workdir'] is not None:
+        if meta.get('cmd'):
+            meta_fd.write("CMD: %s\n" % (meta['cmd']))
+        if meta.get('workdir'):
             meta_fd.write("WORKDIR: %s\n" % (meta['workdir']))
         if private and 'userACL' in meta and meta['userACL'] is not None:
             acls = ','.join(map(lambda x: str(x), meta['userACL']))

--- a/imagegw/shifter_imagegw/dockerv2.py
+++ b/imagegw/shifter_imagegw/dockerv2.py
@@ -486,6 +486,8 @@ class DockerV2Handle(object):
                     resp['workdir'] = config['WorkingDir']
             if 'Entrypoint' in config:
                 resp['entrypoint'] = config['Entrypoint']
+            if 'Cmd' in config:
+                resp['cmd'] = config['Cmd']
         resp['private'] = self.private
         return resp
 

--- a/imagegw/shifter_imagegw/dockerv2_ext.py
+++ b/imagegw/shifter_imagegw/dockerv2_ext.py
@@ -165,6 +165,8 @@ class DockerV2ext(object):
                     resp['workdir'] = config['WorkingDir']
             if 'Entrypoint' in config:
                 resp['entrypoint'] = config['Entrypoint']
+            if 'Cmd' in config:
+                resp['cmd'] = config['Cmd']
             if 'Labels' in config:
                 resp['labels'] = config['Labels']
         resp['private'] = self.private

--- a/imagegw/test/converters_test.py
+++ b/imagegw/test/converters_test.py
@@ -104,6 +104,7 @@ class ConvertersTestCase(unittest.TestCase):
 
         meta = {'workdir': "/tmp/",
                 'entrypoint': '/bin/sh',
+                'cmd': '/script',
                 'env': ['a=b', 'c=d'],
                 'private': True,
                 'userACL': [1000, 1001],
@@ -120,7 +121,7 @@ class ConvertersTestCase(unittest.TestCase):
                     meta['ENV'].append(v)
                 else:
                     meta[k] = v
-        keys = ['WORKDIR', 'FORMAT', 'ENTRY']
+        keys = ['WORKDIR', 'FORMAT', 'ENTRY', 'CMD']
         if 'DISABLE_ACL_METADATA' not in os.environ:
             keys.extend(['USERACL', 'GROUPACL'])
         for key in keys:

--- a/imagegw/test/imageworker_test.py
+++ b/imagegw/test/imageworker_test.py
@@ -101,6 +101,7 @@ class ImageWorkerTestCase(unittest.TestCase):
         self.assertIn('id', req.meta)
         self.assertIn('workdir', req.meta)
         self.assertEqual(req.meta['entrypoint'][0], "/bin/sh")
+        self.assertEqual(req.meta['cmd'][0], "/app.sh")
         self.assertTrue(os.path.exists(req.expandedpath))
 
         return

--- a/src/utility.c
+++ b/src/utility.c
@@ -459,6 +459,8 @@ int pathcmp(const char *a, const char *b) {
 int is_json_array(const char *value) {
     if (value[0] == '[' && value[1] == 'u' && value[2] == '\'') {
         return 1;
+    } else if (value[0] == '[' && value[1] == '\'') {
+        return 1;
     } else {
         return 0;
     }


### PR DESCRIPTION
This addresses #issue313.  This has two sets of changes.
* Add support for Cmd to the image gateway (this was overlooked somehow).
* Fix the is_json method to work for regular json structures.