### PR TITLE
Fix skopeo build in Docker image

### DIFF
--- a/imagegw/Dockerfile
+++ b/imagegw/Dockerfile
@@ -41,7 +41,6 @@ COPY --from=tools /usr/bin/umoci /usr/bin/oci-image-tool /usr/bin/
 
 RUN apt-get -y install skopeo
 COPY --from=skopeo /src/github.com/containers/skopeo/bin/skopeo /usr/bin/
-#COPY --from=skopeo /etc/containers/ /etc/containers/
 
 WORKDIR /usr/src/app
 
@@ -55,10 +54,12 @@ RUN echo "CONFIG_PATH='/config'" >> /usr/src/app/shifter_imagegw/__init__.py
 
 ENV PYTHONPATH=/usr/src/app/
 
+RUN cp /usr/src/app/oci-image-tool-wrapper /usr/local/bin/oci-image-tool-wrapper
+
 # Test that the tools work
 RUN \
-    skopeo && umoci && oci-image-tool
-    
+    skopeo && umoci && /usr/bin/oci-image-tool
+
 
 ENTRYPOINT [ "./entrypoint.sh" ]
 CMD [ ]

--- a/imagegw/Dockerfile
+++ b/imagegw/Dockerfile
@@ -15,8 +15,20 @@ RUN \
     make && make install
 
 # Need newer version of skopeo then what is available from kubic
-FROM debian:sid as skopeo
-RUN apt-get -y update && apt-get -y install skopeo
+#FROM debian:sid as skopeo
+#RUN apt-get -y update && apt-get -y install skopeo
+
+FROM debian:bullseye as skopeo
+RUN \
+    apt-get -y update && \
+    apt-get -y install golang wget go-md2man git make libgpgme-dev libdevmapper-dev
+
+RUN \
+    git clone https://github.com/containers/skopeo $GOPATH/src/github.com/containers/skopeo && \
+    cd $GOPATH/src/github.com/containers/skopeo && \
+    git checkout v1.4.1 && make bin/skopeo && \
+    DISABLE_DOCS=1 make
+
 
 
 FROM python:3.8-slim
@@ -26,8 +38,10 @@ RUN apt-get -y update && apt-get -y install squashfs-tools munge libassuan0 libg
 RUN mkdir /var/run/munge && chown munge /var/run/munge
 
 COPY --from=tools /usr/bin/umoci /usr/bin/oci-image-tool /usr/bin/
-COPY --from=skopeo /usr/bin/skopeo /usr/bin/
-COPY --from=skopeo /etc/containers/ /etc/containers/
+
+RUN apt-get -y install skopeo
+COPY --from=skopeo /src/github.com/containers/skopeo/bin/skopeo /usr/bin/
+#COPY --from=skopeo /etc/containers/ /etc/containers/
 
 WORKDIR /usr/src/app
 
@@ -40,6 +54,11 @@ COPY . /usr/src/app
 RUN echo "CONFIG_PATH='/config'" >> /usr/src/app/shifter_imagegw/__init__.py
 
 ENV PYTHONPATH=/usr/src/app/
+
+# Test that the tools work
+RUN \
+    skopeo && umoci && oci-image-tool
+    
 
 ENTRYPOINT [ "./entrypoint.sh" ]
 CMD [ ]

--- a/imagegw/Makefile.am
+++ b/imagegw/Makefile.am
@@ -2,7 +2,8 @@ SUBDIRS = shifter_imagegw
 
 dist_pkglibexec_SCRIPTS = imagecli.py \
                           imagegwapi.py \
-						  sitecustomize.py
+                          oci-image-tool-wrapper \
+                          sitecustomize.py
 
 dist_sysconf_DATA  = imagemanager.json.example
 

--- a/imagegw/oci-image-tool-wrapper
+++ b/imagegw/oci-image-tool-wrapper
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Extract the proper digest
+D=$(cat $1/index.json|python -mjson.tool|grep -A1 application/vnd.oci.image.manifest.v1+json|grep dig|sed 's/.* .//'|sed 's/".*//')
+
+# Call oci-image-tool on just that digest
+exec /usr/bin/oci-image-tool validate -type image -ref digest=${D} $1
+

--- a/imagegw/shifter_imagegw/dockerv2_ext.py
+++ b/imagegw/shifter_imagegw/dockerv2_ext.py
@@ -131,8 +131,7 @@ class DockerV2ext(object):
         Validate image pull
         """
         self.log("PULLING", 'Validating Image')
-        cmd = ['oci-image-tool', 'validate', '--type',
-               'image', idir]
+        cmd = ['oci-image-tool-wrapper', idir]
         process = Popen(cmd, stdout=PIPE)
         stdout = process.communicate()[0]
         if process.returncode:


### PR DESCRIPTION
The previous method relied on debian sid which has changed and no longer works with the bullseye version used by the main image.